### PR TITLE
Install Node.js LTS instead Node.js Current

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update &&\
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Node.js for rebuilding jupyter lab
-RUN curl -fsSL https://deb.nodesource.com/setup_current.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
 RUN apt-get install -y nodejs
 
 # Install essential Python packages


### PR DESCRIPTION
The latest Node.js is breaking jupyter lab extension installation by failing `jupyter lab build`. Switching to the LTS version fixed it.